### PR TITLE
Switch size function to 'size' HQL function

### DIFF
--- a/commons-rest-sample/src/test/java/io/tackle/commons/sample/PersonListFilteredResourceTest.java
+++ b/commons-rest-sample/src/test/java/io/tackle/commons/sample/PersonListFilteredResourceTest.java
@@ -4,6 +4,8 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
+import io.tackle.commons.sample.entities.Dog;
+import io.tackle.commons.sample.entities.Person;
 import io.tackle.commons.testcontainers.KeycloakTestResource;
 import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
 import io.tackle.commons.tests.SecuredResourceTest;
@@ -128,5 +130,108 @@ import static org.hamcrest.Matchers.iterableWithSize;
                         "_embedded.person[0]._links.size()", is(5),
                         "_embedded.person[0]._links.self.href", is("http://localhost:8081/person/8"),
                         "_links.size()", is(4));
+    }
+
+    @Test
+    // https://github.com/konveyor/tackle-commons-rest/issues/53
+    public void testSortByCollectionSizeWithDeletedEntities() {
+        // initial situation:
+        // person #2 has 2 dogs
+        // person #4 has 1 dog
+        // person #8 has no dogs
+        given()
+                .accept("application/hal+json")
+                .queryParam("sort", "-dogs.size")
+                .when()
+                .get(PATH)
+                .then()
+                .statusCode(200)
+                .body("_embedded.person.size()", is(3),
+                        "_embedded.person.id", containsInRelativeOrder(2, 4, 8),
+                        "_embedded.person[0].dogs.size()", is(2),
+                        "_embedded.person[1].dogs.size()", is(1),
+                        "_embedded.person[2].dogs.size()", is(0));
+
+        // add 2 more dogs to person #4
+        Person d = new Person();
+        d.id = 4L;
+        Dog foo = new Dog();
+        foo.name = "foo";
+        foo.owner = d;
+        foo.id = Long.valueOf(given()
+                .contentType("application/json")
+                .body(foo)
+                .when()
+                .post("/dog")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("id")
+                .toString());
+
+        Dog bar = new Dog();
+        bar.name = "bar";
+        bar.owner = d;
+        bar.id = Long.valueOf(given()
+                .contentType("application/json")
+                .body(bar)
+                .when()
+                .post("/dog")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("id")
+                .toString());
+
+        // check the initial situation has changed accordingly to latest changes:
+        // person #4 has 3 dogs
+        // person #2 has 2 dogs
+        // person #8 has no dogs
+        given()
+                .accept("application/hal+json")
+                .queryParam("sort", "-dogs.size")
+                .when()
+                .get(PATH)
+                .then()
+                .statusCode(200)
+                .body("_embedded.person.size()", is(3),
+                       "_embedded.person.id", containsInRelativeOrder(4, 2, 8),
+                       "_embedded.person[0].dogs.size()", is(3),
+                       "_embedded.person[1].dogs.size()", is(2),
+                       "_embedded.person[2].dogs.size()", is(0));
+
+        // now delete the 2 dogs just created
+        given()
+                .contentType("application/json")
+                .pathParam("id", foo.id)
+                .when()
+                .delete("/dog/{id}")
+                .then()
+                .statusCode(204);
+
+        given()
+                .contentType("application/json")
+                .pathParam("id", bar.id)
+                .when()
+                .delete("/dog/{id}")
+                .then()
+                .statusCode(204);
+
+        // check the initial situation has been restored:
+        // person #2 has 2 dogs
+        // person #4 has 1 dog
+        // person #8 has no dogs
+        given()
+                .accept("application/hal+json")
+                .queryParam("sort", "-dogs.size()")
+                .when()
+                .get(PATH)
+                .then()
+                .statusCode(200)
+                .body("_embedded.person.size()", is(3),
+                        "_embedded.person.id", containsInRelativeOrder(2, 4, 8),
+                        "_embedded.person[0].dogs.size()", is(2),
+                        "_embedded.person[1].dogs.size()", is(1),
+                        "_embedded.person[2].dogs.size()", is(0));
     }
 }

--- a/commons-rest-sample/src/test/java/io/tackle/commons/sample/PersonListFilteredResourceTest.java
+++ b/commons-rest-sample/src/test/java/io/tackle/commons/sample/PersonListFilteredResourceTest.java
@@ -141,7 +141,7 @@ import static org.hamcrest.Matchers.iterableWithSize;
         // person #8 has no dogs
         given()
                 .accept("application/hal+json")
-                .queryParam("sort", "-dogs.size")
+                .queryParam("sort", "-dogs.size()")
                 .when()
                 .get(PATH)
                 .then()
@@ -189,7 +189,7 @@ import static org.hamcrest.Matchers.iterableWithSize;
         // person #8 has no dogs
         given()
                 .accept("application/hal+json")
-                .queryParam("sort", "-dogs.size")
+                .queryParam("sort", "-dogs.size()")
                 .when()
                 .get(PATH)
                 .then()

--- a/commons-rest/src/main/java/io/tackle/commons/resources/ListFilteredResource.java
+++ b/commons-rest/src/main/java/io/tackle/commons/resources/ListFilteredResource.java
@@ -235,8 +235,19 @@ public interface ListFilteredResource<Entity extends PanacheEntity> extends Type
     }
 
     default String getSortValue(String sortQueryParam) {
-        if (sortQueryParam.endsWith(".size()"))  {
-            return String.format("size(%s.%s)", QueryBuilder.DEFAULT_SQL_ROOT_TABLE_ALIAS, sortQueryParam.substring(0, sortQueryParam.lastIndexOf('.')));
-        } else return String.format("%s.%s", QueryBuilder.DEFAULT_SQL_ROOT_TABLE_ALIAS, sortQueryParam);
+        if (sortQueryParam.endsWith(".size()")) {
+            /**
+             * https://github.com/konveyor/tackle-commons-rest/issues/53
+             * It turned out that 'size()' HQL function doesn't take into account
+             * the {@link org.hibernate.annotations.Where#clause()} and this prevents
+             * it from working properly where there are soft-deleted entities.
+             * At the same time, the deprecated 'size' HQL functions works as expected
+             * so, as a workaround, it can be used as long as 'size()' doesn't work properly.
+             * This is also the reason why the proper 'size()' return string value is kept here commented.
+             */
+//            return String.format("size(%s.%s)", QueryBuilder.DEFAULT_SQL_ROOT_TABLE_ALIAS, sortQueryParam.substring(0, sortQueryParam.lastIndexOf('.')));
+            return String.format("%s.%s", QueryBuilder.DEFAULT_SQL_ROOT_TABLE_ALIAS, sortQueryParam.substring(0, sortQueryParam.lastIndexOf('(')));
+        }
+        else return String.format("%s.%s", QueryBuilder.DEFAULT_SQL_ROOT_TABLE_ALIAS, sortQueryParam);
     }
 }


### PR DESCRIPTION
resolve #53 

This change switches the sorting from using the `size(collection)` HQL function to the previous `collection.size` HQL function because  it turned out that the former HQL function doesn't take into account the `@Where#clause` and this prevents it from working properly where there are soft-deleted entities.
At the same time, the deprecated `collection.size` HQL function works as expected so, as a workaround, it can be used as long as `size(collection)` one doesn't work properly.