### PR TITLE
Upgrade to Quarkus 2.5.4.Final

### DIFF
--- a/commons-rest-sample/pom.xml
+++ b/commons-rest-sample/pom.xml
@@ -143,7 +143,7 @@
       <properties>
         <quarkus.package.type>native</quarkus.package.type>
         <quarkus.native.container-build>true</quarkus.native.container-build>
-        <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11</quarkus.native.builder-image>
+        <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11</quarkus.native.builder-image>
       </properties>
     </profile>
     <profile>

--- a/commons-rest-sample/pom.xml
+++ b/commons-rest-sample/pom.xml
@@ -22,6 +22,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-links</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-orm-rest-data-panache</artifactId>
     </dependency>
     <dependency>

--- a/commons-rest-sample/src/main/resources/application.properties
+++ b/commons-rest-sample/src/main/resources/application.properties
@@ -12,4 +12,5 @@ quarkus.http.auth.policy.role-policy1.roles-allowed=user,admin
 quarkus.http.auth.permission.roles1.paths=/*
 quarkus.http.auth.permission.roles1.policy=role-policy1
 
-quarkus.datasource.devservices=false
+quarkus.datasource.devservices.enabled=false
+quarkus.keycloak.devservices.enabled=false

--- a/commons-rest/src/main/java/io/tackle/commons/resources/hal/RestEasyHalLinksProvider.java
+++ b/commons-rest/src/main/java/io/tackle/commons/resources/hal/RestEasyHalLinksProvider.java
@@ -2,6 +2,7 @@ package io.tackle.commons.resources.hal;
 
 import io.quarkus.rest.data.panache.runtime.hal.HalLink;
 import io.quarkus.rest.data.panache.runtime.hal.HalLinksProvider;
+import io.quarkus.rest.data.panache.runtime.resource.RESTEasyClassicResourceLinksProvider;
 import io.quarkus.rest.data.panache.runtime.resource.ResourceLinksProvider;
 
 import java.util.HashMap;
@@ -9,7 +10,7 @@ import java.util.Map;
 
 final class RestEasyHalLinksProvider implements HalLinksProvider {
 
-    private final ResourceLinksProvider linksProvider = new ResourceLinksProvider();
+    private final ResourceLinksProvider linksProvider = new RESTEasyClassicResourceLinksProvider();
 
     @Override
     public Map<String, HalLink> getLinks(Class<?> entityClass) {

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.1.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.4.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <testcontainers.version>1.16.0</testcontainers.version>
     <jacoco.version>0.8.7</jacoco.version>


### PR DESCRIPTION
See [TACKLE-334](https://issues.redhat.com/browse/TACKLE-334). After this PR is merged it is required to release a new version/tag so it can be consumed at:
- https://github.com/konveyor/tackle-controls/pull/195
- https://github.com/konveyor/tackle-application-inventory/pull/172
- https://github.com/konveyor/tackle-pathfinder/pull/169
